### PR TITLE
Route name rebased

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,19 @@ You can use ``simple_route`` as a decorator:
     def my_route(request, name):
         return Response('Hello %s' % name)
 
+Seting route name is optional. By default the route name is
+the dotted path of the Python function.
+
+.. code-block:: python
+
+    @simple_route('/hello/{name}', route_name="custom_name", \
+        append_slash=False)
+    def my_route(request, name):
+        return Response('Hello %s' % name)
+
+    def another_view(request):
+        return request.route_url("custom_name", name="john")
+
 or you can use it from the configurator:
 
 .. code-block:: python

--- a/tests/simple_app.py
+++ b/tests/simple_app.py
@@ -10,6 +10,13 @@ def decorated_view(request):
     return {'foo': 'bar'}
 
 
+@simple_route('/path/to/decorated/view/custom_named_route', \
+              route_name="custom_named_route", renderer='json',
+              append_slash=False)
+def custom_named_route_view(request):
+    return {'foo': 'bar'}
+
+
 @simple_route('/matchdict/{name}/{number}', renderer='json')
 def matchdict_view(request, name, number):
     return {'foo': name, 'bar': number}

--- a/tests/simple_app.py
+++ b/tests/simple_app.py
@@ -10,7 +10,7 @@ def decorated_view(request):
     return {'foo': 'bar'}
 
 
-@simple_route('/path/to/decorated/view/custom_named_route', \
+@simple_route('/path/to/decorated/view/custom_named_route',
               route_name="custom_named_route", renderer='json',
               append_slash=False)
 def custom_named_route_view(request):

--- a/tests/test_simpleroute.py
+++ b/tests/test_simpleroute.py
@@ -1,6 +1,4 @@
 from pyramid import testing
-from pyramid.threadlocal import get_current_request
-from pyramid.url import route_url
 from webtest import TestApp
 
 import pytest
@@ -112,8 +110,6 @@ def test_declarative_config_custom_name():
     config = _make_config()
     config.scan('tests.simple_app')
 
-    app = _make_app(config)
-
     url = testing.DummyRequest().route_url("custom_named_route")
     response = _make_app(config).get(
         url, status=200
@@ -180,11 +176,12 @@ def test_declarative_route_name():
     routes = route_mapper.get_routes()
     route_names = [route.name for route in routes]
 
-    assert len(routes) == 5
+    assert len(routes) == 6
     assert 'MyViewsClass.imperative_view' in route_names
     assert 'MyViewsClass.matchdict_view' in route_names
     assert 'decorated_view' in route_names
     assert 'matchdict_view' in route_names
+    assert 'custom_named_route' in route_names
 
 
 @pytest.mark.integration
@@ -275,4 +272,3 @@ def test_support_pregenerator_without_slash():
     assert response.json == {
         'url': 'http://localhost/test/boomshaka',
     }
-    assert 'custom_named_route' in route_names

--- a/tests/test_simpleroute.py
+++ b/tests/test_simpleroute.py
@@ -1,4 +1,6 @@
 from pyramid import testing
+from pyramid.threadlocal import get_current_request
+from pyramid.url import route_url
 from webtest import TestApp
 
 import pytest
@@ -99,6 +101,22 @@ def test_declarative_config_method():
 
     response = _make_app(config).get(
         '/path/to/decorated/view/method', status=200
+    )
+
+    assert response.content_type == 'application/json'
+    assert response.json == {'foo': 'bar'}
+
+
+@pytest.mark.integration
+def test_declarative_config_custom_name():
+    config = _make_config()
+    config.scan('tests.simple_app')
+
+    app = _make_app(config)
+
+    url = testing.DummyRequest().route_url("custom_named_route")
+    response = _make_app(config).get(
+        url, status=200
     )
 
     assert response.content_type == 'application/json'
@@ -257,3 +275,4 @@ def test_support_pregenerator_without_slash():
     assert response.json == {
         'url': 'http://localhost/test/boomshaka',
     }
+    assert 'custom_named_route' in route_names

--- a/tomb_routes/__init__.py
+++ b/tomb_routes/__init__.py
@@ -56,9 +56,13 @@ def add_simple_route(
 
     target = DottedNameResolver().maybe_resolve(target)
 
-    route_name = target.__name__
-    if 'attr' in kwargs:
-        route_name += '.' + kwargs['attr']
+    # Explicitly supplied route name
+    route_name = kwargs.pop("route_name", None)
+
+    if not route_name:
+        route_name = target.__name__
+        if 'attr' in kwargs:
+            route_name += '.' + kwargs['attr']
 
     current_pregen = kwargs.pop('pregenerator', None)
 


### PR DESCRIPTION
Rebased pull request with flake8 cleanups.

Adding route_name parameter for `@simple_route()` so that you can override Python dotted name with a human friendly version.

I noticed that append_slash is set by default. This causes some confusion when you do `route_url()` you need to also give `route_url("my_route_name", optional_slash=...)` or you will get a KeyError for missing `optional_slash`. This causes some extra confusion and repeating when doing `route_urls()` so I might suggest turning `append_slash` off by default.
